### PR TITLE
fix: can not pod install with react-native-gesture-handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "styled-components": "^5.3.6",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "react-native-gesture-handler": "^2.9.0"
   },
   "resolutions": {
     "@types/react": "18.0.26"
@@ -95,7 +96,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "styled-components": "*"
+    "styled-components": "*",
+    "react-native-gesture-handler": "*"
   },
   "engines": {
     "node": ">= 16.0.0"
@@ -139,7 +141,6 @@
   },
   "dependencies": {
     "eslint-plugin-ft-flow": "^2.0.3",
-    "react-native-gesture-handler": "^2.9.0",
     "react-native-reanimated": "^2.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.5.2",
-    "react-native-gesture-handler": "^2.9.0"
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.17.0"
   },
   "resolutions": {
     "@types/react": "18.0.26"
@@ -97,7 +98,8 @@
     "react": "*",
     "react-native": "*",
     "styled-components": "*",
-    "react-native-gesture-handler": "*"
+    "react-native-gesture-handler": "*",
+    "react-native-reanimated": "*"
   },
   "engines": {
     "node": ">= 16.0.0"
@@ -140,7 +142,6 @@
     ]
   },
   "dependencies": {
-    "eslint-plugin-ft-flow": "^2.0.3",
-    "react-native-reanimated": "^2.17.0"
+    "eslint-plugin-ft-flow": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,9 +2260,9 @@
     "@types/node" "*"
 
 "@types/hammerjs@^2.0.36":
-  version "2.0.41"
-  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
-  integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
+  version "2.0.43"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.43.tgz#8660dd1e0e5fd979395e2f999e670cdb9484d1e9"
+  integrity sha512-wqxfwHk83RS7+6OpytGdo5wqkqtvx+bGaIs1Rwm5NrtQHUfL4OgWs/5p0OipmjmT+fexePh37Ek+mqIpdNjQKA==
 
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
@@ -8491,9 +8491,9 @@ react-native-codegen@^0.71.5:
     nullthrows "^1.1.1"
 
 react-native-gesture-handler@^2.9.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.12.0.tgz#59ca9d97e4c71f70b9c258f14a1a081f4c689976"
-  integrity sha512-rr+XwVzXAVpY8co25ukvyI38fKCxTQjz7WajeZktl8qUPdh1twnSExgpT47DqDi4n+m+OiJPAnHfZOkqqAQMOg==
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.13.3.tgz#417dac3d063fd61589f21187ad732372d01c8feb"
+  integrity sha512-6sNXtmRfYxQWgH0TjQX03QQ4UfCyM8jX1Ee1jXc3uNgefk03qapGGxZ2noXodGWKHzpsqMxB0O1lFLGew0GRrw==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
## Summary


## Features


## Bugs
- Root cause: Pod Install Failed when install rn-base-component in rn-base-project
- Solution: move react-native-gesture-handler into peerDependencies instead of dependencies to resolve conflict versions

## Check List
- [ ] Your code builds clean without any errors or warnings.
- [ ] Check coding convention.
- [ ] Updated Storybook components and stories to reflect any changes made to the UI.
- [ ] Test covers all edge cases and coverage is greater than or equal to 80%.

## Proof of Completeness
<img alt="Screenshot changes introduced" src="<uploaded_image_url>" width="250" />
OR
Video link
