### PR TITLE
feat: intergrate theme for single Button component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ example/react-native.config.js
 example/metro.config.js
 example/babel.config.js
 example/node_modules
+lib

--- a/example/src/stories/Button.stories.tsx
+++ b/example/src/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type {ComponentMeta, ComponentStory} from '@storybook/react'
 
-import {Button} from 'rn-base-component'
+import {Button, ButtonOutline, ButtonPrimary, ButtonSecondary, ButtonTransparent} from 'rn-base-component'
 import {StyleSheet, View} from 'react-native'
 
 export default {
@@ -13,26 +13,15 @@ export const Basic: ComponentStory<typeof Button> = args => (
   <View style={styles.container}>
     <Button {...args} />
     <View style={styles.spacer} />
-    <Button
-      {...args}
-      text="I'm an outline button"
-      textColor="black"
-      outline
-      outlineColor="black"
-      outlineWidth={2}
-      backgroundColor="transparent"
-    />
+    <Button {...args} text="Disable me!" disabled />
     <View style={styles.spacer} />
-    <Button {...args} text="Disable me!" outline outlineWidth={2} disabled />
+    <ButtonOutline {...args} text="I'm an outline button" />
     <View style={styles.spacer} />
-    <Button
-      {...args}
-      text="I have a border radius"
-      outline
-      outlineWidth={1}
-      borderRadius={12}
-      backgroundColor="red"
-    />
+    <ButtonPrimary {...args} text="I'm a primary button" />
+    <View style={styles.spacer} />
+    <ButtonSecondary {...args} text="I'm a primary button" />
+    <View style={styles.spacer} />
+    <ButtonTransparent {...args} text="I'm a primary button" />
   </View>
 )
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -24,6 +24,10 @@ export type ButtonProps = {
    */
   disabled?: boolean
   /**
+   * Color of the disabled button background
+   */
+  disabledColor?: string
+  /**
    * Button will have outline style
    */
   outline?: boolean
@@ -60,6 +64,7 @@ const Button: React.FC<ButtonProps> = ({
   outlineWidth,
   borderRadius,
   disabled,
+  disabledColor,
   textProps,
   textStyle,
   style,
@@ -70,7 +75,9 @@ const Button: React.FC<ButtonProps> = ({
     <ButtonWrapper
       onPress={onPress}
       activeOpacity={0.8}
-      backgroundColor={disabled ? ButtonTheme.disabledColor : backgroundColor ?? ButtonTheme.backgroundColor}
+      backgroundColor={
+        disabled ? disabledColor ?? ButtonTheme.disabledColor : backgroundColor ?? ButtonTheme.backgroundColor
+      }
       outline={outline}
       outlineColor={outlineColor}
       outlineWidth={outlineWidth}
@@ -78,7 +85,7 @@ const Button: React.FC<ButtonProps> = ({
       disabled={disabled}
       style={[{height: ButtonTheme.height}, StyleSheet.flatten(style)]}
       {...props}>
-      <Label {...textProps} style={textStyle} color={textColor ?? ButtonTheme.labelColor}>
+      <Label {...textProps} style={textStyle} color={textColor ?? ButtonTheme.textColor}>
         {text}
       </Label>
     </ButtonWrapper>
@@ -97,7 +104,7 @@ const ButtonWrapper = styled.TouchableOpacity(
   }: Omit<ButtonProps, 'text' | 'onPress'> & {theme?: ITheme}) => ({
     paddingVertical: theme?.spacing.small,
     paddingHorizontal: theme?.spacing.slim,
-    borderRadius: borderRadius,
+    borderRadius,
     backgroundColor: disabled ? theme?.colors.muted : backgroundColor || theme?.colors.green,
     alignSelf: 'center',
     ...(outline && {
@@ -108,7 +115,7 @@ const ButtonWrapper = styled.TouchableOpacity(
 )
 
 const Label = styled.Text(({theme, color}: {color?: string; theme?: ITheme}) => ({
-  color: color,
+  color,
   fontWeight: theme?.fontWeights?.bold,
 }))
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import styled from 'styled-components/native'
-import {metrics} from '../../helpers'
-import type {TouchableOpacityProps, TextProps, StyleProp, TextStyle, ViewStyle} from 'react-native'
-import type {ITheme} from 'src/theme'
+import {
+  type TouchableOpacityProps,
+  type TextProps,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+  StyleSheet,
+} from 'react-native'
+import type {ITheme} from '../../theme'
+import {useTheme} from '../../hooks'
 
 export type ButtonProps = {
   onPress: () => void
@@ -57,23 +64,26 @@ const Button: React.FC<ButtonProps> = ({
   textStyle,
   style,
   ...props
-}) => (
-  <ButtonWrapper
-    onPress={onPress}
-    activeOpacity={0.8}
-    backgroundColor={backgroundColor}
-    outline={outline}
-    outlineColor={outlineColor}
-    outlineWidth={outlineWidth}
-    borderRadius={borderRadius}
-    disabled={disabled}
-    style={style}
-    {...props}>
-    <Label {...textProps} style={textStyle} color={textColor}>
-      {text}
-    </Label>
-  </ButtonWrapper>
-)
+}) => {
+  const ButtonTheme = useTheme().components.Button
+  return (
+    <ButtonWrapper
+      onPress={onPress}
+      activeOpacity={0.8}
+      backgroundColor={disabled ? ButtonTheme.disabledColor : backgroundColor ?? ButtonTheme.backgroundColor}
+      outline={outline}
+      outlineColor={outlineColor}
+      outlineWidth={outlineWidth}
+      borderRadius={borderRadius ?? ButtonTheme.borderRadius}
+      disabled={disabled}
+      style={[{height: ButtonTheme.height}, StyleSheet.flatten(style)]}
+      {...props}>
+      <Label {...textProps} style={textStyle} color={textColor ?? ButtonTheme.labelColor}>
+        {text}
+      </Label>
+    </ButtonWrapper>
+  )
+}
 
 const ButtonWrapper = styled.TouchableOpacity(
   ({
@@ -87,7 +97,7 @@ const ButtonWrapper = styled.TouchableOpacity(
   }: Omit<ButtonProps, 'text' | 'onPress'> & {theme?: ITheme}) => ({
     paddingVertical: theme?.spacing.small,
     paddingHorizontal: theme?.spacing.slim,
-    borderRadius: borderRadius || metrics.borderRadius,
+    borderRadius: borderRadius,
     backgroundColor: disabled ? theme?.colors.muted : backgroundColor || theme?.colors.green,
     alignSelf: 'center',
     ...(outline && {
@@ -98,7 +108,7 @@ const ButtonWrapper = styled.TouchableOpacity(
 )
 
 const Label = styled.Text(({theme, color}: {color?: string; theme?: ITheme}) => ({
-  color: color || 'white',
+  color: color,
   fontWeight: theme?.fontWeights?.bold,
 }))
 

--- a/src/components/Button/ButtonOutline.tsx
+++ b/src/components/Button/ButtonOutline.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import {useTheme} from '../../hooks'
+import type {ButtonProps} from './Button'
+import Button from './Button'
+
+const ButtonOutline: React.FC<ButtonProps> = ({
+  textColor,
+  backgroundColor,
+  outlineColor,
+  outlineWidth,
+  disabled,
+  ...props
+}) => {
+  const ButtonOutlineTheme = useTheme().components.ButtonOutline
+  return (
+    <Button
+      outline
+      outlineWidth={outlineWidth ?? ButtonOutlineTheme.outlineWidth}
+      outlineColor={outlineColor ?? ButtonOutlineTheme.outlineColor}
+      backgroundColor={
+        disabled ? ButtonOutlineTheme.disabledColor : backgroundColor ?? ButtonOutlineTheme.backgroundColor
+      }
+      textColor={textColor ?? ButtonOutlineTheme.labelColor}
+      {...props}
+    />
+  )
+}
+
+export default ButtonOutline

--- a/src/components/Button/ButtonOutline.tsx
+++ b/src/components/Button/ButtonOutline.tsx
@@ -3,27 +3,9 @@ import {useTheme} from '../../hooks'
 import type {ButtonProps} from './Button'
 import Button from './Button'
 
-const ButtonOutline: React.FC<ButtonProps> = ({
-  textColor,
-  backgroundColor,
-  outlineColor,
-  outlineWidth,
-  disabled,
-  ...props
-}) => {
+const ButtonOutline: React.FC<ButtonProps> = props => {
   const ButtonOutlineTheme = useTheme().components.ButtonOutline
-  return (
-    <Button
-      outline
-      outlineWidth={outlineWidth ?? ButtonOutlineTheme.outlineWidth}
-      outlineColor={outlineColor ?? ButtonOutlineTheme.outlineColor}
-      backgroundColor={
-        disabled ? ButtonOutlineTheme.disabledColor : backgroundColor ?? ButtonOutlineTheme.backgroundColor
-      }
-      textColor={textColor ?? ButtonOutlineTheme.labelColor}
-      {...props}
-    />
-  )
+  return <Button outline {...ButtonOutlineTheme} {...props} />
 }
 
 export default ButtonOutline

--- a/src/components/Button/ButtonPrimary.tsx
+++ b/src/components/Button/ButtonPrimary.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import {useTheme} from '../../hooks'
+import type {ButtonProps} from './Button'
+import Button from './Button'
+
+const ButtonPrimary: React.FC<ButtonProps> = ({textColor, backgroundColor, disabled, ...props}) => {
+  const ButtonPrimaryTheme = useTheme().components.ButtonPrimary
+  return (
+    <Button
+      backgroundColor={
+        disabled ? ButtonPrimaryTheme.disabledColor : backgroundColor ?? ButtonPrimaryTheme.backgroundColor
+      }
+      textColor={textColor ?? ButtonPrimaryTheme.labelColor}
+      {...props}
+    />
+  )
+}
+
+export default ButtonPrimary

--- a/src/components/Button/ButtonPrimary.tsx
+++ b/src/components/Button/ButtonPrimary.tsx
@@ -3,17 +3,9 @@ import {useTheme} from '../../hooks'
 import type {ButtonProps} from './Button'
 import Button from './Button'
 
-const ButtonPrimary: React.FC<ButtonProps> = ({textColor, backgroundColor, disabled, ...props}) => {
+const ButtonPrimary: React.FC<ButtonProps> = props => {
   const ButtonPrimaryTheme = useTheme().components.ButtonPrimary
-  return (
-    <Button
-      backgroundColor={
-        disabled ? ButtonPrimaryTheme.disabledColor : backgroundColor ?? ButtonPrimaryTheme.backgroundColor
-      }
-      textColor={textColor ?? ButtonPrimaryTheme.labelColor}
-      {...props}
-    />
-  )
+  return <Button {...ButtonPrimaryTheme} {...props} />
 }
 
 export default ButtonPrimary

--- a/src/components/Button/ButtonSecondary.tsx
+++ b/src/components/Button/ButtonSecondary.tsx
@@ -3,19 +3,9 @@ import {useTheme} from '../../hooks'
 import type {ButtonProps} from './Button'
 import Button from './Button'
 
-const ButtonSecondary: React.FC<ButtonProps> = ({textColor, backgroundColor, disabled, ...props}) => {
+const ButtonSecondary: React.FC<ButtonProps> = props => {
   const ButtonSecondaryTheme = useTheme().components.ButtonSecondary
-  return (
-    <Button
-      backgroundColor={
-        disabled
-          ? ButtonSecondaryTheme.disabledColor
-          : backgroundColor ?? ButtonSecondaryTheme.backgroundColor
-      }
-      textColor={textColor ?? ButtonSecondaryTheme.labelColor}
-      {...props}
-    />
-  )
+  return <Button {...ButtonSecondaryTheme} {...props} />
 }
 
 export default ButtonSecondary

--- a/src/components/Button/ButtonSecondary.tsx
+++ b/src/components/Button/ButtonSecondary.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import {useTheme} from '../../hooks'
+import type {ButtonProps} from './Button'
+import Button from './Button'
+
+const ButtonSecondary: React.FC<ButtonProps> = ({textColor, backgroundColor, disabled, ...props}) => {
+  const ButtonSecondaryTheme = useTheme().components.ButtonSecondary
+  return (
+    <Button
+      backgroundColor={
+        disabled
+          ? ButtonSecondaryTheme.disabledColor
+          : backgroundColor ?? ButtonSecondaryTheme.backgroundColor
+      }
+      textColor={textColor ?? ButtonSecondaryTheme.labelColor}
+      {...props}
+    />
+  )
+}
+
+export default ButtonSecondary

--- a/src/components/Button/ButtonTransparent.tsx
+++ b/src/components/Button/ButtonTransparent.tsx
@@ -3,19 +3,9 @@ import {useTheme} from '../../hooks'
 import type {ButtonProps} from './Button'
 import Button from './Button'
 
-const ButtonTransparent: React.FC<ButtonProps> = ({textColor, backgroundColor, disabled, ...props}) => {
+const ButtonTransparent: React.FC<ButtonProps> = props => {
   const ButtonTransparentTheme = useTheme().components.ButtonTransparent
-  return (
-    <Button
-      backgroundColor={
-        disabled
-          ? ButtonTransparentTheme.disabledColor
-          : backgroundColor ?? ButtonTransparentTheme.backgroundColor
-      }
-      textColor={textColor ?? ButtonTransparentTheme.labelColor}
-      {...props}
-    />
-  )
+  return <Button outline {...ButtonTransparentTheme} {...props} />
 }
 
 export default ButtonTransparent

--- a/src/components/Button/ButtonTransparent.tsx
+++ b/src/components/Button/ButtonTransparent.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import {useTheme} from '../../hooks'
+import type {ButtonProps} from './Button'
+import Button from './Button'
+
+const ButtonTransparent: React.FC<ButtonProps> = ({textColor, backgroundColor, disabled, ...props}) => {
+  const ButtonTransparentTheme = useTheme().components.ButtonTransparent
+  return (
+    <Button
+      backgroundColor={
+        disabled
+          ? ButtonTransparentTheme.disabledColor
+          : backgroundColor ?? ButtonTransparentTheme.backgroundColor
+      }
+      textColor={textColor ?? ButtonTransparentTheme.labelColor}
+      {...props}
+    />
+  )
+}
+
+export default ButtonTransparent

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,5 @@
+export {default as Button} from './Button'
+export {default as ButtonOutline} from './ButtonOutline'
+export {default as ButtonPrimary} from './ButtonPrimary'
+export {default as ButtonSecondary} from './ButtonSecondary'
+export {default as ButtonTransparent} from './ButtonTransparent'

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import styled from 'styled-components/native'
 import type {ITheme} from '../../theme'
-import {theme, Images} from '../../theme'
+import {Images} from '../../theme'
 import {
   BOUNCE_EFFECT_IN,
   BOUNCE_EFFECT_OUT,
@@ -26,6 +26,7 @@ import {
   DEFAULT_OPACITY,
   DEFAULT_BOUNCE_EFFECT,
 } from './constants'
+import {useTheme} from '../../hooks'
 
 type CustomStyleProp = StyleProp<ViewStyle> | Array<StyleProp<ViewStyle>>
 type CustomTextStyleProp = StyleProp<TextStyle> | Array<StyleProp<TextStyle>>
@@ -48,11 +49,14 @@ type IconContainerStyle = {
   backgroundColor: string
   disabled: boolean
   disableOpacity: number
+  borderRadius?: number
 }
 type InnerIconContainerStyle = {
   theme?: ITheme
   size?: number
   borderColor: string
+  borderRadius?: number
+  borderWidth?: number
 }
 
 export interface ICheckboxProps extends BaseTouchableProps {
@@ -60,12 +64,18 @@ export interface ICheckboxProps extends BaseTouchableProps {
   size?: number
   /** the text of the checkbox */
   text?: string
+  /** border radius of the checkbox */
+  borderRadius?: number
+  /** border width the checkbox */
+  borderWidth?: number
   /** color when checkbox is checked, default #ffc484 */
   fillColor?: string
   /** define the status of checkbox */
   isChecked?: boolean
   /** color when checkbox is unchecked, default transparent */
   unfillColor?: string
+  /** color of the check mark, default is white */
+  checkMarkColor?: string
   /** opacity of checkbox when disable, default 0.5 */
   disableOpacity?: number
   /** disable the checkbox text */
@@ -110,8 +120,11 @@ const Checkbox = forwardRef<ICheckboxMethods, ICheckboxProps>(
       iconStyle,
       iconComponent,
       iconImageStyle,
-      fillColor = theme.colors.primary,
-      unfillColor = theme.colors.transparent,
+      fillColor,
+      unfillColor,
+      checkMarkColor,
+      borderRadius,
+      borderWidth,
       disableBuiltInState = false,
       isChecked,
       innerIconStyle,
@@ -130,6 +143,7 @@ const Checkbox = forwardRef<ICheckboxMethods, ICheckboxProps>(
     },
     forwardedRef,
   ) => {
+    const CheckboxTheme = useTheme().components.Checkbox
     const [checked, setChecked] = useState(false)
     const bounceValue = useSharedValue(DEFAULT_BOUNCE_EFFECT)
 
@@ -159,14 +173,24 @@ const Checkbox = forwardRef<ICheckboxMethods, ICheckboxProps>(
       return (
         <IconContainerAnimated
           testID={'icon-container'}
-          size={size}
-          backgroundColor={checked ? fillColor : unfillColor}
           disabled={disabled}
           disableOpacity={disableOpacity}
+          {...CheckboxTheme}
+          backgroundColor={
+            checked
+              ? fillColor ?? (CheckboxTheme.fillColor as string)
+              : unfillColor ?? (CheckboxTheme.unfillColor as string)
+          }
           style={[animatedIconContainerStyle, StyleSheet.flatten(iconStyle)]}>
-          <InnerIconContainer style={innerIconStyle} size={size} borderColor={fillColor}>
+          <InnerIconContainer style={innerIconStyle} {...CheckboxTheme}>
             {iconComponent ||
-              (checkStatus && <StyledImage source={checkIconImageSource} style={iconImageStyle} />)}
+              (checkStatus && (
+                <StyledImage
+                  source={checkIconImageSource}
+                  style={iconImageStyle}
+                  tintColor={checkMarkColor ?? CheckboxTheme.checkMarkColor}
+                />
+              ))}
           </InnerIconContainer>
         </IconContainerAnimated>
       )
@@ -230,22 +254,23 @@ const TextContainer = styled.View((props: TextContainerStyle) => ({
 const IconContainer = styled.View((props: IconContainerStyle) => ({
   alignItems: 'center',
   justifyContent: 'center',
-  width: props.size || props.theme?.sizes?.narrow,
-  height: props.size || props.theme?.sizes?.narrow,
-  borderRadius: props.size || props.theme?.sizes?.narrow,
+  width: props.size,
+  height: props.size,
+  borderRadius: props.borderRadius || props.size,
   backgroundColor: props.backgroundColor,
   opacity: props.disabled ? props.disableOpacity : DEFAULT_OPACITY,
 }))
+
 const IconContainerAnimated = Animated.createAnimatedComponent<ICheckboxProps & {backgroundColor: string}>(
   IconContainer,
 )
 
 const InnerIconContainer = styled.View((props: InnerIconContainerStyle) => ({
-  borderWidth: props.theme?.borderWidths?.tiny,
+  borderWidth: props.borderWidth,
   alignItems: 'center',
   justifyContent: 'center',
-  width: props.size || props.theme?.sizes?.narrow,
-  height: props.size || props.theme?.sizes?.narrow,
-  borderRadius: props.size || props.theme?.sizes?.narrow,
+  width: props.size,
+  height: props.size,
+  borderRadius: props.borderRadius || props.size,
   borderColor: props?.borderColor,
 }))

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,6 @@
 import Accordion from './Accordion/Accordion'
 import RadioButton from './RadioButton/RadioButton'
-import Button from './Button/Button'
+import {Button, ButtonOutline, ButtonPrimary, ButtonSecondary, ButtonTransparent} from './Button'
 
 import Progress from './Progress/Progress'
 import Checkbox from './Checkbox/Checkbox'
@@ -9,5 +9,19 @@ import Slider from './Slider/Slider'
 import Card from './Card/Card'
 import TextInput from './TextInput/TextInput'
 
-export {Button, CodeInput, Checkbox, Progress, Slider, RadioButton, Card, TextInput, Accordion}
+export {
+  Button,
+  ButtonOutline,
+  ButtonPrimary,
+  ButtonSecondary,
+  ButtonTransparent,
+  CodeInput,
+  Checkbox,
+  Progress,
+  Slider,
+  RadioButton,
+  Card,
+  TextInput,
+  Accordion,
+}
 export * from './Text/Text'

--- a/src/theme/components/Button/Button.ts
+++ b/src/theme/components/Button/Button.ts
@@ -7,11 +7,13 @@ export type ButtonThemeProps = {
   disabledColor?: string
   borderRadius?: number
   labelColor?: string
+  outlineWidth?: number
+  outlineColor?: string
 }
 
 export const ButtonTheme: ButtonThemeProps = {
   height: metrics.xxl,
-  backgroundColor: base.colors.green,
+  backgroundColor: base.colors.primary,
   disabledColor: base.colors.muted,
   borderRadius: metrics.borderRadius,
   labelColor: base.colors.white,

--- a/src/theme/components/Button/Button.ts
+++ b/src/theme/components/Button/Button.ts
@@ -1,20 +1,18 @@
 import base from '../../base'
 import {metrics} from '../../../helpers'
+import type {ButtonProps} from '../../../components/Button/Button'
 
 export type ButtonThemeProps = {
   height?: number
-  backgroundColor?: string
-  disabledColor?: string
-  borderRadius?: number
-  labelColor?: string
-  outlineWidth?: number
-  outlineColor?: string
-}
+} & Pick<
+  ButtonProps,
+  'backgroundColor' | 'disabledColor' | 'borderRadius' | 'textColor' | 'outlineWidth' | 'outlineColor'
+>
 
 export const ButtonTheme: ButtonThemeProps = {
   height: metrics.xxl,
   backgroundColor: base.colors.primary,
   disabledColor: base.colors.muted,
   borderRadius: metrics.borderRadius,
-  labelColor: base.colors.white,
+  textColor: base.colors.white,
 }

--- a/src/theme/components/Button/ButtonOutline.ts
+++ b/src/theme/components/Button/ButtonOutline.ts
@@ -1,0 +1,10 @@
+import base from '../../base'
+import {type ButtonThemeProps, ButtonTheme} from './Button'
+
+export const ButtonOutlineTheme: ButtonThemeProps = {
+  ...ButtonTheme,
+  backgroundColor: 'transparent',
+  labelColor: base.colors.primary,
+  outlineWidth: base.borderWidths.tiny,
+  outlineColor: base.colors.primary,
+}

--- a/src/theme/components/Button/ButtonOutline.ts
+++ b/src/theme/components/Button/ButtonOutline.ts
@@ -4,7 +4,7 @@ import {type ButtonThemeProps, ButtonTheme} from './Button'
 export const ButtonOutlineTheme: ButtonThemeProps = {
   ...ButtonTheme,
   backgroundColor: 'transparent',
-  labelColor: base.colors.primary,
+  textColor: base.colors.primary,
   outlineWidth: base.borderWidths.tiny,
   outlineColor: base.colors.primary,
 }

--- a/src/theme/components/Button/ButtonPrimary.ts
+++ b/src/theme/components/Button/ButtonPrimary.ts
@@ -1,0 +1,8 @@
+import base from '../../base'
+import {type ButtonThemeProps, ButtonTheme} from './Button'
+
+export const ButtonPrimaryTheme: ButtonThemeProps = {
+  ...ButtonTheme,
+  backgroundColor: base.colors.primary,
+  labelColor: base.colors.white,
+}

--- a/src/theme/components/Button/ButtonPrimary.ts
+++ b/src/theme/components/Button/ButtonPrimary.ts
@@ -4,5 +4,5 @@ import {type ButtonThemeProps, ButtonTheme} from './Button'
 export const ButtonPrimaryTheme: ButtonThemeProps = {
   ...ButtonTheme,
   backgroundColor: base.colors.primary,
-  labelColor: base.colors.white,
+  textColor: base.colors.white,
 }

--- a/src/theme/components/Button/ButtonSecondary.ts
+++ b/src/theme/components/Button/ButtonSecondary.ts
@@ -4,5 +4,5 @@ import {type ButtonThemeProps, ButtonTheme} from './Button'
 export const ButtonSecondaryTheme: ButtonThemeProps = {
   ...ButtonTheme,
   backgroundColor: base.colors.secondary,
-  labelColor: base.colors.white,
+  textColor: base.colors.white,
 }

--- a/src/theme/components/Button/ButtonSecondary.ts
+++ b/src/theme/components/Button/ButtonSecondary.ts
@@ -1,0 +1,8 @@
+import base from '../../base'
+import {type ButtonThemeProps, ButtonTheme} from './Button'
+
+export const ButtonSecondaryTheme: ButtonThemeProps = {
+  ...ButtonTheme,
+  backgroundColor: base.colors.secondary,
+  labelColor: base.colors.white,
+}

--- a/src/theme/components/Button/ButtonTheme.ts
+++ b/src/theme/components/Button/ButtonTheme.ts
@@ -1,0 +1,18 @@
+import base from '../../base'
+import {metrics} from '../../../helpers'
+
+export type ButtonThemeProps = {
+  height?: number
+  backgroundColor?: string
+  disabledColor?: string
+  borderRadius?: number
+  labelColor?: string
+}
+
+export const ButtonTheme: ButtonThemeProps = {
+  height: metrics.xxl,
+  backgroundColor: base.colors.green,
+  disabledColor: base.colors.muted,
+  borderRadius: metrics.borderRadius,
+  labelColor: base.colors.white,
+}

--- a/src/theme/components/Button/ButtonTransparent.ts
+++ b/src/theme/components/Button/ButtonTransparent.ts
@@ -4,5 +4,5 @@ import {type ButtonThemeProps, ButtonTheme} from './Button'
 export const ButtonTransparentTheme: ButtonThemeProps = {
   ...ButtonTheme,
   backgroundColor: 'transparent',
-  labelColor: base.colors.primary,
+  textColor: base.colors.primary,
 }

--- a/src/theme/components/Button/ButtonTransparent.ts
+++ b/src/theme/components/Button/ButtonTransparent.ts
@@ -1,0 +1,8 @@
+import base from '../../base'
+import {type ButtonThemeProps, ButtonTheme} from './Button'
+
+export const ButtonTransparentTheme: ButtonThemeProps = {
+  ...ButtonTheme,
+  backgroundColor: 'transparent',
+  labelColor: base.colors.primary,
+}

--- a/src/theme/components/Button/index.ts
+++ b/src/theme/components/Button/index.ts
@@ -1,0 +1,5 @@
+export * from './Button'
+export * from './ButtonOutline'
+export * from './ButtonPrimary'
+export * from './ButtonSecondary'
+export * from './ButtonTransparent'

--- a/src/theme/components/Checkbox.ts
+++ b/src/theme/components/Checkbox.ts
@@ -1,0 +1,17 @@
+import base from '../base'
+import {metrics} from '../../helpers'
+import type {ICheckboxProps} from '../../components/Checkbox/Checkbox'
+
+export type CheckboxThemeProps = Pick<
+  ICheckboxProps,
+  'size' | 'borderRadius' | 'fillColor' | 'unfillColor' | 'checkMarkColor' | 'borderWidth'
+>
+
+export const CheckboxTheme: CheckboxThemeProps = {
+  size: base.sizes.narrow,
+  borderRadius: metrics.borderRadius,
+  fillColor: base.colors.primary,
+  unfillColor: base.colors.transparent,
+  checkMarkColor: base.colors.white,
+  borderWidth: base.borderWidths.tiny,
+}

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -5,6 +5,7 @@ import {
   ButtonSecondaryTheme,
   ButtonTransparentTheme,
 } from './Button'
+import {CheckboxTheme} from './Checkbox'
 
 export default {
   Button: ButtonTheme,
@@ -12,4 +13,5 @@ export default {
   ButtonPrimary: ButtonPrimaryTheme,
   ButtonSecondary: ButtonSecondaryTheme,
   ButtonTransparent: ButtonTransparentTheme,
+  Checkbox: CheckboxTheme,
 }

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,5 +1,15 @@
-import {ButtonTheme} from './Button/ButtonTheme'
+import {
+  ButtonTheme,
+  ButtonOutlineTheme,
+  ButtonPrimaryTheme,
+  ButtonSecondaryTheme,
+  ButtonTransparentTheme,
+} from './Button'
 
 export default {
   Button: ButtonTheme,
+  ButtonOutline: ButtonOutlineTheme,
+  ButtonPrimary: ButtonPrimaryTheme,
+  ButtonSecondary: ButtonSecondaryTheme,
+  ButtonTransparent: ButtonTransparentTheme,
 }

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,0 +1,5 @@
+import {ButtonTheme} from './Button/ButtonTheme'
+
+export default {
+  Button: ButtonTheme,
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import type {ColorModeOptions} from '../core/color-mode/type'
 import base from './base'
+import components from './components'
 
 const config: ColorModeOptions = {
   useSystemColorMode: false,
@@ -11,6 +12,7 @@ const darkColors = base.colors
 
 const theme = {
   ...base,
+  components,
   config,
   darkColors,
 }


### PR DESCRIPTION
## Summary
- Adding default theme for Button component
- Adding other Button style: ButtonPrimary, ButtonSecondary, ButtonOutline, ButtonTransparent
- Allow default theming for these customize Button

## Features


## Bugs


## Check List
- [ ] Your code builds clean without any errors or warnings.
- [ ] Check coding convention.
- [ ] Updated Storybook components and stories to reflect any changes made to the UI.
- [ ] Test covers all edge cases and coverage is greater than or equal to 80%.

## Proof of Completeness
![Screenshot 2023-11-06 at 15 26 11](https://github.com/saigontechnology/rn-base-component/assets/114563576/c2cacde0-83e6-412b-b03e-7d7b35314fd0)
![Screenshot 2023-11-07 at 11 18 30](https://github.com/saigontechnology/rn-base-component/assets/114563576/e8f2e8f4-75ad-4b10-98d8-ef6931f78c03)


