### PR TITLE
fix: center content for button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -116,6 +116,7 @@ const ButtonWrapper = styled.TouchableOpacity(
     paddingHorizontal: theme?.spacing.slim,
     borderRadius,
     backgroundColor: disabled ? theme?.colors.muted : backgroundColor || theme?.colors.green,
+    justifyContent: 'center',
     ...((leftIcon || rightIcon) && {
       alignItems: 'center',
     }),


### PR DESCRIPTION
## Summary
Fix: content of button is not center if we set button height larger than default value

## Features


## Bugs


## Check List
- [ ] Your code builds clean without any errors or warnings.
- [ ] Check coding convention.
- [ ] Updated Storybook components and stories to reflect any changes made to the UI.
- [ ] Test covers all edge cases and coverage is greater than or equal to 80%.

## Proof of Completeness

